### PR TITLE
remove extraneous args param from init

### DIFF
--- a/examples/plot_results.py
+++ b/examples/plot_results.py
@@ -1,5 +1,5 @@
 # after running
-# python train-pytorch-simple.py | tee results.txt 
+# python train-pytorch-simple.py | tee results.txt
 # this script will plot the validation accuracy
 
 import numpy as np
@@ -18,7 +18,7 @@ with open('results.txt') as f:
 
 acc = np.asarray(acc)
 x = [i*50000/1e6 for i in range(1, len(acc))]
-y = [np.amax(acc[:i])/100.0 for i in range(1, len(acc))]
+y = [np.amax(acc[:i]) for i in range(1, len(acc) + 1)]
 plt.plot(x, y)
 plt.xlabel('cumulative samples seen in training (M)')
 plt.ylabel('validation accuracy')

--- a/train-pytorch.py
+++ b/train-pytorch.py
@@ -174,6 +174,8 @@ def test(epoch, model, data_loader, logger, loss_function=nnf.cross_entropy):
         logger.record('test', 'acc', correct_percent / 100.0)
         logger.new_row('test')
 
+    return correct_percent
+
 
 def get_data_loader():
     """ helper to return the data loader """

--- a/train-pytorch.py
+++ b/train-pytorch.py
@@ -40,7 +40,7 @@ parser.add_argument('--reset-every', type=str, default="", help='reset generator
 # Model parameters
 parser.add_argument('--batch-size', type=int, default=400, metavar='N',
                     help='input batch size for training (default: 400)')
-parser.add_argument('--activations', nargs='+', 
+parser.add_argument('--activations', nargs='+',
                     help='list of activations', default=['softmax', 'softmax'], type=str)
 parser.add_argument('--lr', type=float, default=1e-3,
                     help='learning rate (default: 1e-3)')
@@ -235,7 +235,6 @@ def run():
                         ],
                         path=args.filelog,
                         file_prefix=short_name,
-                        args=args
                     )
         logger.set_info('note', args.note)
         logger.set_info('uuid', logger.uuid)


### PR DESCRIPTION
  - Filelogger had an extra args param that caused a crash in `train-pytorch.py`
  - fix return value in test fn